### PR TITLE
Add support for validation scripts via api.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.2 (TBD)
+
+### Added
+
+-   Validation scripts via api.py
+    -   protocol state option: `check_validity_call: <validation-function>`
+    -   validation-function has to correspond to a function name in app/api.py that takes the automaton and the annotation as arguments.
+
+### Removed
+
+### Changed
+
 ## 2.0.1 (25-02-2022)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The setup consists of 5 parts:
 4. [Deploy server](#deploy-server)
 5. [Add data](#add-data)
 
-### Python environment
+### 1. Python environment
 
 First install the python environment.
 
@@ -43,7 +43,7 @@ OR install from requirements.txt with pip or whatever you fancy.
 pip install -r requirements.txt
 ```
 
-### Database setup
+### 2. Database setup
 
 First initialize the database with
 
@@ -57,19 +57,19 @@ Then add an admin account with
 flask add-admin
 ```
 
-### Annotation protocol
+### 3. Annotation protocol
 
 Write your custom annotation protocol into protocol.yml. Refer to the [wiki](https://github.com/uds-lsv/human/wiki) for documentation on how to do this and see our example protocols (under `/examples`) for inspiration.
 
 Whenever you change any state names in protocol.yml, afterwards be sure to run
 
 ```sh
-flask run reset-annotations
+flask reset-annotations
 ```
 
 This will reset the annotations table in the database and is necessary to properly save annotations after a change in the protocol.
 
-### Deploy server
+### 4. Deploy server
 
 To run a server you have 2 possibilities:
 
@@ -90,7 +90,7 @@ When running HUMAN in a production environment on a server we recommend using gu
 
 For docker refer to the [https://github.com/uds-lsv/human/wiki/Docker/](wiki).
 
-### Adding data
+### 5. Adding data
 
 To add a file with data, start the server, log in with your admin account, and go to "Data Console". There you can upload the file.
 Be sure that it is a tab separated file with the three columns "content", "context" and "meta".
@@ -99,22 +99,26 @@ When you want to display files you can use "Upload Folder" in "Data Console" and
 
 # Try our Examples!
 
-WIP
+After the setup you can try these examples.
 
-<!-- Picture Annotation:
+First always reset the database with `flask reset-database`
 
-1. Copy and rename `/example/protocol_example_picture.json` to `/protocol.json`
-2. Run `setup.sh`
-3. Log in with your administrator account and upload the folder `/example/picture`
-4. Upload the file `/example/data_example_picture.csv`
-5. Go back to home and start annotating.
+### Picture Annotation
 
-Text Annotation:
+1. Copy `/example/protocol_image.yml` to `/protocol.yml`
+2. Run `flask reset-annotations`
+3. Log in with your administrator account and go to the upload console
+4. Upload folder `/example/picture`
+5. Upload file `/example/data_example_picture.csv`
+6. Go back to home page and start annotating.
 
-1. Copy and rename `/example/protocol_example_text.json` to `/protocol.json`
-2. Run `setup.sh`
-3. Log in with your administrator account and upload the file `/example/data_example_text.csv`
-4. Go back to home and start annotating. -->
+### Text Annotation
+
+1. Copy `/example/protocol_text.yml` to `/protocol.yml`
+2. Run `flask reset-annotations`
+3. Log in with your administrator account and go to the upload console
+4. Upload file `/example/data_example_text.csv`
+5. Go back to home page and start annotating.
 
 # Development
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -50,6 +50,20 @@ def trigger_transition():
         response = automaton.get_response()
     return response
 
+@login_required
+@app.route('/api/check_validity', methods=["POST", "OPTIONS"])
+def check_validity():
+    if not request.is_json:
+        return "Unexpected Parameters"
+    automaton: AnnotationAutomaton = current_user.automaton
+    req = request.json
+    api_call = getattr(api, req['check_validity_call'])
+    api_ret = api_call(automaton, req)
+    if type(api_ret) != dict:
+        raise error_handler.AutomatonError('API call did not return dict type')
+    return jsonify(api_ret)
+
+@login_required
 @app.route('/api/callAPI', methods=["POST", "OPTIONS"])
 def call_api():
     """

--- a/app/user_handler.py
+++ b/app/user_handler.py
@@ -82,7 +82,7 @@ def load_user_by_name(username):
         uid,username,email,fname,lname,password,user_type,is_approved,annotated = db.execute(
             'SELECT id,username,email,given_name,surname,password,user_type,is_approved,annotated FROM user WHERE username = ?', (username,)
             ).fetchone()
-        user = User(uid,username,email,fname,lname,password,user_type,is_approved,annotated)
+        user = User(uid,username,email,fname,lname,password,user_type,is_approved,annotated, None)
     except Exception as e:
         app.logger.error("Error occurred while loading the user {}".format(username))
         app.logger.error("Error occurred while loading the user error:".format(str(e)))

--- a/client/src/data.ts
+++ b/client/src/data.ts
@@ -19,6 +19,7 @@ class DefaultDict {
 
 export class Data {
     static data = undefined
+    static state = undefined
     static text: string = ''
     static content: string = ''
     static context: string = ''
@@ -35,6 +36,7 @@ export class Data {
     static current_task: Task = undefined
     static reset() {
         Data.data = undefined
+        Data.state = undefined
         Data.text = ''
         Data.context = ''
         Data.picture = undefined

--- a/client/src/imageTasks.ts
+++ b/client/src/imageTasks.ts
@@ -645,13 +645,11 @@ export class PicturePolygonTask implements Task {
     async onEntry(question: string, answer: string = 'Continue') {
         await loadPicture()
         $('#question').append(question)
-        const yes = $(
-            '<button class="btn btn-primary btn-block" style="margin: 10px 0 10px 0;position: relative">' +
-                answer +
-                '</button>'
+        const answer_button = $(
+            `<button id="answer_button" class="btn btn-primary btn-block" style="margin: 10px 0 10px 0;position: relative">${answer}</button>`
         )
-        yes.on('click', () => {
-            yes.off('click')
+        answer_button.on('click', () => {
+            answer_button.attr('disabled')
             let scaled_polygons = []
             paperMain.project.activeLayer.children.forEach((child) => {
                 if (child instanceof paperMain.Path) {
@@ -671,7 +669,7 @@ export class PicturePolygonTask implements Task {
             data['annotation'] = scaled_polygons
             nextState('NEXT', data) // 2nd arg passed to backend
         })
-        $('#answer').append(yes)
+        $('#answer').append(answer_button)
         await setupMain(Data['picture'])
         this.setupHotKeys()
     }
@@ -729,13 +727,11 @@ export class PictureBBoxesTask implements Task {
     async onEntry(question: string, answer: string = 'Continue') {
         await loadPicture()
         $('#question').append(question)
-        const yes = $(
-            '<button class="btn btn-primary btn-block" style="margin: 10px 0 10px 0;position: relative">' +
-                answer +
-                '</button>'
+        const answer_button = $(
+            `<button id="answer_button" class="btn btn-primary btn-block" style="margin: 10px 0 10px 0;position: relative">${answer}</button>`
         )
-        yes.on('click', () => {
-            yes.off('click')
+        answer_button.on('click', () => {
+            answer_button.attr('disabled')
             let scaled_polygons = []
             paperMain.project.activeLayer.children.forEach((child) => {
                 if (child instanceof paperMain.Path) {
@@ -755,7 +751,7 @@ export class PictureBBoxesTask implements Task {
             data['annotation'] = scaled_polygons
             nextState('NEXT', data) // 2nd arg passed to backend
         })
-        $('#answer').append(yes)
+        $('#answer').append(answer_button)
         await setupMain(Data['picture'])
         this.setupHotKeys()
     }

--- a/client/src/pictureLabeling.ts
+++ b/client/src/pictureLabeling.ts
@@ -421,17 +421,19 @@ export function showMultilabelBBox(
         // controls in right side container
         $('#question').append(question)
 
-        let yes = $('<button class="btn btn-primary"></button>')
-        yes.append(answer)
-        yes.on('click', () => {
-            yes.off('click')
+        const answer_button = $(
+            '<button id="answer_button" class="btn btn-primary"></button>'
+        )
+        answer_button.append(answer)
+        answer_button.on('click', () => {
+            answer_button.attr('disabled')
             setAnnotation(multilabelBBoxTask)
             buttonContainer.remove()
             nextState('next', {
                 annotation: multilabelBBoxTask.annotations,
             })
         })
-        $('#answer').empty().append(yes)
+        $('#answer').empty().append(answer_button)
 
         if (Data.active >= 1) {
             let back = $('<button class="btn btn-primary"></button>')
@@ -528,10 +530,10 @@ export function showAnnotatePicture(
         }
         // add buttons
         $('#question').append(question)
-        let yes = $('<button class="btn btn-primary"></button>')
-        yes.append(answer)
-        yes.on('click', () => {
-            yes.off('click')
+        let answer_button = $('<button class="btn btn-primary"></button>')
+        answer_button.append(answer)
+        answer_button.on('click', () => {
+            answer_button.attr('disabled')
             rescaleGuiBBoxes()
             const scaledbboxes = extractBBoxes(layer)
                 .sort(BBox.sortBBoxArray)
@@ -540,7 +542,7 @@ export function showAnnotatePicture(
                 })
             nextState('next', { annotation: scaledbboxes })
         })
-        $('#answer').append(yes)
+        $('#answer').append(answer_button)
     })
 }
 
@@ -740,12 +742,14 @@ class LabelBBoxTask extends Task {
 
         setupAutocompleteList(predicted, this)
 
-        let yes = $('<button class="btn btn-primary"></button>')
+        const answer_button = $(
+            '<button id="answer_button" class="btn btn-primary"></button>'
+        )
 
         if (index < Data.predicted_labels.length - 1) {
-            yes.append('Next')
-            yes.on('click', () => {
-                yes.off('click')
+            answer_button.append('Next')
+            answer_button.on('click', () => {
+                answer_button.attr('disabled')
                 const self = this
                 $('#input-item, .word-list-item').each(function () {
                     if ($(this).hasClass('active')) {
@@ -760,14 +764,14 @@ class LabelBBoxTask extends Task {
                 this.setCurrentIndex(index + 1)
             })
         } else {
-            yes.append('Finish')
-            yes.on('click', () =>
+            answer_button.append('Finish')
+            answer_button.on('click', () =>
                 nextState('next', {
                     annotation: this.annotations,
                 })
             )
         }
-        $('#answer').empty().append(yes)
+        $('#answer').empty().append(answer_button)
     }
     drawBBoxLabels() {}
 

--- a/client/src/tasks.ts
+++ b/client/src/tasks.ts
@@ -50,8 +50,8 @@ export async function showText() {
 
     let text = add_spans(Data.data['content'])
     $('.comment-content').append(text)
-    if (Data.data['context'] == ' ') {
-        console.log('aaaaa')
+
+    if (Data.data['context'] == ' ' || Data.data['context'] == '') {
         $('#contentContainer').css('height', '100%')
         $('#bottomContainer').hide()
     } else {
@@ -77,19 +77,23 @@ export class BooleanTask implements Task {
         // await loadWords()
         // $('#controls').hide()
         $('#question').append(question)
-        let yes = $('<button class="btn btn-primary">Yes</button>')
+        let yes = $(
+            '<button id="answer_button" class="btn btn-primary">Yes</button>'
+        )
         yes.on('click', (event) => {
-            yes.off('click')
+            yes.attr('disabled')
+
             // send yes
-            this.onExit()
             nextState('YES', { annotation: 1 })
         })
         $('#answer').append(yes)
-        let no = $('<button class="btn btn-primary">No</button>')
+        let no = $(
+            '<button id="answer_button" class="btn btn-primary">No</button>'
+        )
         no.on('click', (event) => {
-            no.off('click')
+            no.attr('disabled')
+
             // send no
-            this.onExit()
             nextState('NO', { annotation: 0 })
         })
         $('#answer').append(no)
@@ -140,14 +144,14 @@ export class SelectTask implements Task {
             $(formgroup).append(option)
             $(formgroup).append(label) // append everything to group
         }
-        const answer_b = $(
-            `<button type="button" class="btn btn-primary">${answer}</button>`
+        const answer_button = $(
+            `<button id="answer_button" type="button" class="btn btn-primary">${answer}</button>`
         ) // next button
-        $('#answer').append(answer_b)
+        $('#answer').append(answer_button)
 
         // on click for button
-        answer_b.on('click', (event) => {
-            answer_b.off('click')
+        answer_button.on('click', (event) => {
+            answer_button.attr('disabled')
             // get checked radio button and run statemachine NEXT with its value
             for (let i = 0; i < options.length; i++) {
                 // console.log($('#form' + i))
@@ -204,13 +208,13 @@ export class CheckmarkTask implements Task {
         }
 
         // add next button
-        const answer_b = $(
-            `<button type="button" class="btn btn-primary">${answer}</button>`
+        const answer_button = $(
+            `<button id="answer_button" type="button" class="btn btn-primary">${answer}</button>`
         )
-        $('#answer').append(answer_b)
+        $('#answer').append(answer_button)
         // on click for button
-        answer_b.on('click', (event) => {
-            answer_b.off('click')
+        answer_button.on('click', (event) => {
+            answer_button.attr('disabled')
             let checkedVals = [] // for checkboxes
 
             // get checked checkboxes and run statemachine next with its value
@@ -242,17 +246,17 @@ export class FreetextTask implements Task {
         )
         $('#controls').append(textarea)
 
-        const button = $(
-            '<button type="button" class="btn btn-primary"></button'
+        const answer_button = $(
+            '<button id="answer_button" type="button" class="btn btn-primary"></button'
         ) // next button
-        button.append(answer) // append text
-        button.on('click', (event) => {
-            button.off('click')
+        answer_button.append(answer) // append text
+        answer_button.on('click', (event) => {
+            answer_button.attr('disabled', 'disabled')
             nextState('NEXT', {
                 annotation: textarea.val(),
             })
         })
-        $('#answer').append(button)
+        $('#answer').append(answer_button)
     }
 
     async onExit() {
@@ -273,10 +277,12 @@ export class ChoosePageTask implements Task {
 
     async onEntry(question: string, answer: string = 'Correct Page') {
         $('#question').append(question)
-        let yes = $('<button class="btn btn-primary"></button>')
-        yes.append(answer)
-        yes.on('click', async (e) => {
-            yes.off('click')
+        let answer_button = $(
+            '<button id="answer_button" class="btn btn-primary"></button>'
+        )
+        answer_button.append(answer)
+        answer_button.on('click', async (e) => {
+            answer_button.attr('disabled')
             nextState(
                 'NEXT',
                 await new Promise((resolve, reject) => {
@@ -300,7 +306,7 @@ export class ChoosePageTask implements Task {
                 })
             )
         })
-        $('#answer').append(yes)
+        $('#answer').append(answer_button)
         PDFService.showPDF(Data.pdf)
     }
     async onExit() {
@@ -320,10 +326,12 @@ export class ReadTask implements Task {
     async onEntry(question: string, answer: string = 'Continue') {
         $('#question').append(question)
         let answer_button = $(
-            '<button class="btn btn-primary">' + answer + '</button>'
+            '<button id="answer_button" class="btn btn-primary">' +
+                answer +
+                '</button>'
         )
         answer_button.on('click', (event) => {
-            answer_button.off('click')
+            answer_button.attr('disabled')
             nextState('NEXT', {})
         })
         $('#answer').append(answer_button)
@@ -399,19 +407,20 @@ export class LabelTextTask implements Task {
                 })
             )
         }
-        const button = $(
-            '<button type="button" class="btn btn-primary"></button>'
+        const answer_button = $(
+            '<button id="answer_button" type="button" class="btn btn-primary"></button>'
         ) // next button
-        button.append(answer)
-        button.on('click', (event) => {
-            $('.comment-content').off('click tap')
+        answer_button.append(answer)
+        answer_button.on('click', (event) => {
+            // $('.comment-content').off('click tap')
+            answer_button.attr('disabled')
             const markers_copy = JSON.stringify(this.markers)
             nextState('NEXT', { annotation: markers_copy })
         })
         // $('#question').empty();
         // $('#answer').empty();
         $('#question').append(question)
-        $('#answer').append(button)
+        $('#answer').append(answer_button)
     }
     async onExit() {
         $('#question').empty()


### PR DESCRIPTION
Validation scripts via api.py
-   protocol state option: `check_validity_call: <validation-function>`
-   validation-function has to correspond to a function name in app/api.py that takes the automaton and the annotation as arguments.
